### PR TITLE
Expose Argon2.no_user_verify as 'fake_verify'

### DIFF
--- a/test/antigone_test.gleam
+++ b/test/antigone_test.gleam
@@ -48,3 +48,11 @@ pub fn readme_low_cost_example_test() {
     |> antigone.hash(<<password:utf8>>)
   let assert "$argon2id$v=19$m=256,t=1,p=4$" <> _ = hash
 }
+
+pub fn fake_verify_test() {
+  // Check fake_verify is callable without failure
+  antigone.hasher()
+  |> antigone.time_cost(1)
+  |> antigone.memory_cost(8)
+  |> antigone.fake_verify()
+}


### PR DESCRIPTION
Not sure about the naming here and I'm not experienced at gleam or its ffi but this is my best attempt.

The comment is partly copied from the Argon2 docs. I don't know what the policy is there:

  https://hexdocs.pm/argon2_elixir/Argon2.html#no_user_verify/1