### PR TITLE
docs: fix example code in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,12 @@ gleam add antigone
 ```
 ```gleam
 import antigone
+import gleam/bit_array
 
 pub fn main() {
   // You've got a password or token you wish to hash so that you can verify it
   // later without having to store the password or hash itself.
-  let password = "blink182"
+  let password = bit_array.from_string("blink182")
 
   // Hash the password with the default configuration:
   antigone.hash(antigone.hasher(), password)


### PR DESCRIPTION
Currently running the example in `README.md` results in the following type error:
```
  Compiling testing
error: Type mismatch
  ┌─ /home/ethan/code/antigone-test/src/testing.gleam:9:36
  │
9 │   antigone.hash(antigone.hasher(), password)
  │                                    ^^^^^^^^

Expected type:

    BitArray

Found type:

    String

```

This pr adds the necessary type conversion.

edit:

I forgot to include the system info:
```sh
> gleam --version
gleam 1.2.0

> gleam deps list
antigone 1.1.0
argon2_elixir 4.0.0
castore 1.0.7
certifi 2.13.0
comeonin 5.4.0
elixir_make 0.8.3
gleam_stdlib 0.38.0
gleeunit 1.1.2
```